### PR TITLE
Command text removed

### DIFF
--- a/Simple.Wpf.Terminal/Terminal.cs
+++ b/Simple.Wpf.Terminal/Terminal.cs
@@ -494,7 +494,9 @@ namespace Simple.Wpf.Terminal
         private void AddItems(object[] items)
         {
             Contract.Requires(items != null);
-            
+
+            var command = AggregateAfterPrompt();
+            ClearAfterPrompt();
             _paragraph.Inlines.Remove(_promptInline);
 
             var inlines = items.SelectMany(x =>
@@ -515,8 +517,8 @@ namespace Simple.Wpf.Terminal
             }).ToArray();
 
             _paragraph.Inlines.AddRange(inlines);
-
             AddPrompt();
+            _paragraph.Inlines.Add(new Run(command));
             CaretPosition = CaretPosition.DocumentEnd;
         }
 


### PR DESCRIPTION
If command text is present after the prompt when items are added to the ItemsSource, the text is removed from after the prompt and placed in front of the item added.
This means if data is added at regular intervals from an asynchronous source, the command text can become corrupted whist typing, before the return key is hit.